### PR TITLE
Web: update Perma Curate to Kleros Scout

### DIFF
--- a/web/src/layout/Header/navbar/DappList.tsx
+++ b/web/src/layout/Header/navbar/DappList.tsx
@@ -116,9 +116,9 @@ const ITEMS = [
     url: "https://veascan.io",
   },
   {
-    text: "Perma Curate",
+    text: "Kleros Scout",
     Icon: Curate,
-    url: "https://perma-curate.eth.limo/",
+    url: "https://klerosscout.eth.limo",
   },
   {
     text: "POH V1",


### PR DESCRIPTION
Changed "Perma Curate" in the Dapplist component to "Kleros Scout" and changed link to https://klerosscout.eth.limo/

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the name and URL of a Dapp from "Perma Curate" to "Kleros Scout" with the corresponding link change.

### Detailed summary
- Renamed Dapp from "Perma Curate" to "Kleros Scout"
- Updated URL from "https://perma-curate.eth.limo/" to "https://klerosscout.eth.limo"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->