### PR TITLE
feat: change ipfs link

### DIFF
--- a/web/src/components/PreviewCard/Terms/AttachedFile.tsx
+++ b/web/src/components/PreviewCard/Terms/AttachedFile.tsx
@@ -17,7 +17,7 @@ interface IAttachedFile {
 }
 
 const AttachedFile: React.FC<IAttachedFile> = ({ extraDescriptionUri }) => {
-  const href = extraDescriptionUri?.replace(/^ipfs:\/\//, "https://ipfs.kleros.io/ipfs/");
+  const href = extraDescriptionUri?.replace(/^ipfs:\/\//, "https://cdn.kleros.link/ipfs/");
 
   return extraDescriptionUri ? (
     <StyledA href={href} target="_blank" rel="noreferrer">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `AttachedFile` component in `PreviewCard` to change the IPFS link prefix from `ipfs.kleros.io` to `cdn.kleros.link`.

### Detailed summary
- Updated the `href` variable to replace `ipfs://` with `https://cdn.kleros.link/ipfs/` instead of `https://ipfs.kleros.io/ipfs/`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->