### PR TITLE
chore: remove walletconnect api key

### DIFF
--- a/web/src/context/Web3Provider.tsx
+++ b/web/src/context/Web3Provider.tsx
@@ -9,7 +9,7 @@ import { useToggleTheme } from "hooks/useToggleThemeContext";
 import { useTheme } from "styled-components";
 
 const chains = [arbitrumSepolia, mainnet, gnosisChiado];
-const projectId = process.env.WALLETCONNECT_PROJECT_ID ?? "6efaa26765fa742153baf9281e218217";
+const projectId = process.env.WALLETCONNECT_PROJECT_ID ?? "";
 
 const { publicClient, webSocketPublicClient } = configureChains(chains, [
   alchemyProvider({ apiKey: process.env.ALCHEMY_API_KEY ?? "" }),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to remove the default `WALLETCONNECT_PROJECT_ID` value and set it to an empty string if not provided.

### Detailed summary
- Removed default `WALLETCONNECT_PROJECT_ID` value
- Set `projectId` to an empty string if `WALLETCONNECT_PROJECT_ID` is not provided

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->