### PR TITLE
feat: bump ui components library version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@filebase/client": "^0.0.5",
-    "@kleros/ui-components-library": "^2.8.1",
+    "@kleros/ui-components-library": "^2.12.0",
     "@sentry/react": "^7.93.0",
     "@sentry/tracing": "^7.93.0",
     "@supabase/supabase-js": "^2.39.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4766,7 +4766,7 @@ __metadata:
     "@filebase/client": "npm:^0.0.5"
     "@graphql-codegen/cli": "npm:^4.0.1"
     "@graphql-codegen/client-preset": "npm:^4.1.0"
-    "@kleros/ui-components-library": "npm:^2.8.1"
+    "@kleros/ui-components-library": "npm:^2.12.0"
     "@netlify/functions": "npm:^1.6.0"
     "@parcel/transformer-svg-react": "npm:2.11.0"
     "@parcel/watcher": "npm:~2.2.0"
@@ -4835,9 +4835,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kleros/ui-components-library@npm:^2.8.1":
-  version: 2.8.1
-  resolution: "@kleros/ui-components-library@npm:2.8.1"
+"@kleros/ui-components-library@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "@kleros/ui-components-library@npm:2.12.0"
   dependencies:
     "@datepicker-react/hooks": "npm:^2.8.4"
     "@swc/helpers": "npm:^0.3.2"
@@ -4854,7 +4854,7 @@ __metadata:
     react-dom: ^18.0.0
     react-is: ^18.0.0
     styled-components: ^5.3.3
-  checksum: 10/78c05b2217a4d04d554a81cee6fbcdb6c6d2a1ccb92a42118d75b477e076b0c21682916e65a8495c8d70e0763ab7a9062080d4c2f29fb49fc55536879b65f446
+  checksum: 10/9c53e9ce217a5dd6c0f5dc1b19c8c14fb6f4843f5cf7a0eb1b1ae9561ead583c1bcf5bc2687e7f678007363768be3de95f5d573298b00b965d13a563c4b59495
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates dependencies in `package.json` and `yarn.lock` related to `@kleros/ui-components-library` to version `2.12.0`.

### Detailed summary
- Updated `@kleros/ui-components-library` to version `2.12.0` in dependencies
- Updated resolution and version for `@kleros/ui-components-library` in yarn.lock

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->