### PR TITLE
fix: getipfsurl on the attachedfile

### DIFF
--- a/web/src/components/PreviewCard/Terms/AttachedFile.tsx
+++ b/web/src/components/PreviewCard/Terms/AttachedFile.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { responsiveSize } from "styles/responsiveSize";
 import AttachmentIcon from "svgs/icons/attachment.svg";
+import { getIpfsUrl } from "utils/getIpfsUrl";
 
 const StyledA = styled.a`
   display: flex;
@@ -17,7 +18,7 @@ interface IAttachedFile {
 }
 
 const AttachedFile: React.FC<IAttachedFile> = ({ extraDescriptionUri }) => {
-  const href = extraDescriptionUri?.replace(/^ipfs:\/\//, "https://cdn.kleros.link/ipfs/");
+  const href = extraDescriptionUri && getIpfsUrl(extraDescriptionUri);
 
   return extraDescriptionUri ? (
     <StyledA href={href} target="_blank" rel="noreferrer">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new function `getIpfsUrl` to dynamically generate IPFS URLs for attached files in `AttachedFile.tsx`.

### Detailed summary
- Added `getIpfsUrl` function import from `utils`
- Updated `href` assignment in `AttachedFile` component to use `getIpfsUrl` for dynamic IPFS URL generation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the way URLs are generated for attached files, enhancing reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->