### PR TITLE
chore(web): bump-ui-components-library-to-2.15.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@cyntler/react-doc-viewer": "^1.16.3",
     "@filebase/client": "^0.0.5",
-    "@kleros/ui-components-library": "^2.12.0",
+    "@kleros/ui-components-library": "^2.15.0",
     "@middy/core": "^5.3.5",
     "@middy/http-json-body-parser": "^5.3.5",
     "@sentry/react": "^7.93.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5210,7 +5210,7 @@ __metadata:
     "@filebase/client": "npm:^0.0.5"
     "@graphql-codegen/cli": "npm:^4.0.1"
     "@graphql-codegen/client-preset": "npm:^4.1.0"
-    "@kleros/ui-components-library": "npm:^2.12.0"
+    "@kleros/ui-components-library": "npm:^2.15.0"
     "@middy/core": "npm:^5.3.5"
     "@middy/http-json-body-parser": "npm:^5.3.5"
     "@netlify/functions": "npm:^1.6.0"
@@ -5282,9 +5282,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kleros/ui-components-library@npm:^2.12.0":
-  version: 2.12.0
-  resolution: "@kleros/ui-components-library@npm:2.12.0"
+"@kleros/ui-components-library@npm:^2.15.0":
+  version: 2.15.0
+  resolution: "@kleros/ui-components-library@npm:2.15.0"
   dependencies:
     "@datepicker-react/hooks": "npm:^2.8.4"
     "@swc/helpers": "npm:^0.3.2"
@@ -5301,7 +5301,7 @@ __metadata:
     react-dom: ^18.0.0
     react-is: ^18.0.0
     styled-components: ^5.3.3
-  checksum: 10/9c53e9ce217a5dd6c0f5dc1b19c8c14fb6f4843f5cf7a0eb1b1ae9561ead583c1bcf5bc2687e7f678007363768be3de95f5d573298b00b965d13a563c4b59495
+  checksum: 10/7c97e8fe45b1cd002a0aaf7fe4670b8c668a3abbbab82fac9261ef9a8382ccaf7d4a974ee54b8f299f1e8e7b68e58dab1f3f31d7c8b3b60c58a5af8abdf4a783
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `@kleros/ui-components-library` package from `2.12.0` to `2.15.0` in both `web/package.json` and `yarn.lock`, ensuring that the project uses the latest features and fixes available in this library.

### Detailed summary
- Updated `@kleros/ui-components-library` from `^2.12.0` to `^2.15.0` in `web/package.json`.
- Updated `@kleros/ui-components-library` from `npm:^2.12.0` to `npm:^2.15.0` in `yarn.lock`.
- Changed version resolution for `@kleros/ui-components-library` to `2.15.0` in `yarn.lock`.
- Updated checksum for `@kleros/ui-components-library` in `yarn.lock`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the app to utilize the latest version of the UI components library, enhancing performance and functionality.

- **Bug Fixes**
	- Incremented version number to reflect the latest updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->