### PR TITLE
feat(Escrow): cap the amount

### DIFF
--- a/contracts/src/EscrowUniversal.sol
+++ b/contracts/src/EscrowUniversal.sol
@@ -48,7 +48,7 @@ contract EscrowUniversal is IEscrow, IArbitrableV2 {
         _;
     }
 
-    modifier ShouldNotExceedCap(IERC20 _token, uint256 _amount) {
+    modifier shouldNotExceedCap(IERC20 _token, uint256 _amount) {
         if (amountCaps[_token] != 0 && _amount > amountCaps[_token]) revert AmountExceedsCap();
         _;
     }
@@ -136,7 +136,7 @@ contract EscrowUniversal is IEscrow, IArbitrableV2 {
         uint256 _deadline,
         string memory _transactionUri,
         address payable _seller
-    ) external payable override ShouldNotExceedCap(NATIVE, msg.value) returns (uint256 transactionID) {
+    ) external payable override shouldNotExceedCap(NATIVE, msg.value) returns (uint256 transactionID) {
         Transaction storage transaction = transactions.push();
         transaction.buyer = payable(msg.sender);
         transaction.seller = _seller;
@@ -163,7 +163,7 @@ contract EscrowUniversal is IEscrow, IArbitrableV2 {
         uint256 _deadline,
         string memory _transactionUri,
         address payable _seller
-    ) external override ShouldNotExceedCap(_token, _amount) returns (uint256 transactionID) {
+    ) external override shouldNotExceedCap(_token, _amount) returns (uint256 transactionID) {
         // Transfers token from sender wallet to contract.
         if (!_token.safeTransferFrom(msg.sender, address(this), _amount)) revert TokenTransferFailed();
         Transaction storage transaction = transactions.push();

--- a/contracts/src/interfaces/IEscrow.sol
+++ b/contracts/src/interfaces/IEscrow.sol
@@ -180,4 +180,5 @@ interface IEscrow {
     error SettlementPeriodNotOver();
     error NotSupported();
     error TokenTransferFailed();
+    error AmountExceedsCap();
 }


### PR DESCRIPTION
Initially planned to create a separate contract for this feature, but since it's universal escrow contract it might be better to put it directly there as an option

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new error handling mechanism and a cap on the amount of tokens that can be used in `EscrowUniversal` transactions. It adds functionality to manage these caps and ensures that transactions do not exceed specified limits.

### Detailed summary
- Added `AmountExceedsCap()` error in `IEscrow.sol`.
- Introduced `amountCaps` mapping in `EscrowUniversal` to set caps for token amounts.
- Created `shouldNotExceedCap` modifier to enforce the cap on token amounts during transactions.
- Added `changeAmountCap` function for updating the cap on specific tokens.
- Applied the `shouldNotExceedCap` modifier to `payable` and token transfer functions to enforce limits.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new mapping to set maximum allowable amounts for ERC20 tokens in escrow transactions.
	- Added a modifier to validate transaction amounts against defined caps.
	- Implemented a function to allow governance to adjust amount caps for specific tokens.
	- Enhanced error handling with a new error declaration for exceeding transaction limits.

- **Bug Fixes**
	- Improved transaction validation to prevent exceeding specified limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->