### PR TITLE
Value cap must be configured for an ERC20 tx, for the preview release only

### DIFF
--- a/contracts/src/EscrowUniversal.sol
+++ b/contracts/src/EscrowUniversal.sol
@@ -49,7 +49,7 @@ contract EscrowUniversal is IEscrow, IArbitrableV2 {
     }
 
     modifier shouldNotExceedCap(IERC20 _token, uint256 _amount) {
-        if (amountCaps[_token] != 0 && _amount > amountCaps[_token]) revert AmountExceedsCap();
+        if (_amount > amountCaps[_token]) revert AmountExceedsCap();
         _;
     }
 


### PR DESCRIPTION
The value cap will be lifted later for the full launch.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refines the `shouldNotExceedCap` modifier in the `EscrowUniversal` contract by removing an unnecessary check for a zero cap. It simplifies the condition to only check if the `_amount` exceeds the cap for the specified token.

### Detailed summary
- Modified the `shouldNotExceedCap` modifier:
  - Removed the check for `amountCaps[_token] != 0`.
  - Retained the condition to revert if `_amount` exceeds `amountCaps[_token]`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated cap enforcement logic in the escrow contract to improve consistency in amount validation.
	- Simplified token amount cap checking mechanism to prevent potential edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->