### PR TITLE
fix: toastify fix

### DIFF
--- a/web/src/styles/global-style.ts
+++ b/web/src/styles/global-style.ts
@@ -121,4 +121,9 @@ export const GlobalStyle = createGlobalStyle`
   .hiddenCanvasElement{
    display: none;
   }
+
+  [class*="Toastify__toast-container"] {
+    top: unset;
+    padding-top: 20px !important;
+  }
 `;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the global styles in the `global-style.ts` file to modify the appearance of toast notifications.

### Detailed summary
- Added styles for elements with classes containing `Toastify__toast-container`.
- Set `top` property to `unset`.
- Added `padding-top` of `20px` with `!important` to ensure it overrides other styles.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the display of toast notifications by adjusting their vertical spacing, ensuring a more balanced and consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->