### PR TITLE
chore(web): update-subgraph-status-lib

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -98,7 +98,7 @@
     "react-toastify": "^9.1.3",
     "react-use": "^17.4.3",
     "styled-components": "^5.3.11",
-    "subgraph-status": "^1.2.3",
+    "subgraph-status": "^1.2.4",
     "viem": "^2.22.22",
     "wagmi": "^2.14.10"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4709,7 +4709,7 @@ __metadata:
     react-toastify: "npm:^9.1.3"
     react-use: "npm:^17.4.3"
     styled-components: "npm:^5.3.11"
-    subgraph-status: "npm:^1.2.3"
+    subgraph-status: "npm:^1.2.4"
     typescript: "npm:^5.7.3"
     viem: "npm:^2.22.22"
     vite: "npm:^5.4.2"
@@ -27324,9 +27324,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"subgraph-status@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "subgraph-status@npm:1.2.3"
+"subgraph-status@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "subgraph-status@npm:1.2.4"
   dependencies:
     react-slick: "npm:^0.30.2"
     slick-carousel: "npm:^1.8.1"
@@ -27336,7 +27336,7 @@ __metadata:
     "@types/react-dom": ^18.3.0
     react: ^18.3.1
     react-dom: ^18.3.1
-  checksum: 10/a125ec618073493026a29e9120a1fc73f8a3ad36b24815fe2f4ecd65f8cefa8b19d5bc072ee3f9b72172436c783fc918f6f13b396dddb935c5e70a3bd748888d
+  checksum: 10/8088ec7440f5d2811fae8b6520f531c60f41a786384a874005646240d22570601a359e5681912ae125aa81e1208f9e2e7c359ca1c81ab92363bbf27688b880bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `subgraph-status` package from `1.2.3` to `1.2.4` in both `package.json` and `yarn.lock`, along with a checksum change.

### Detailed summary
- Updated `subgraph-status` from `^1.2.3` to `^1.2.4` in `package.json`.
- Updated `subgraph-status` from `npm:^1.2.3` to `npm:^1.2.4` in `yarn.lock`.
- Changed checksum for `subgraph-status` from `10/a125ec...` to `10/8088ec...`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated a key dependency to a new version to enhance compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->