### PR TITLE
docs(Escrow): typo

### DIFF
--- a/contracts/src/EscrowUniversal.sol
+++ b/contracts/src/EscrowUniversal.sol
@@ -37,7 +37,7 @@ contract EscrowUniversal is IEscrow, IArbitrableV2 {
     uint256 public feeTimeout; // Time in seconds a party can take to pay arbitration fees before being considered unresponsive and lose the dispute.
     uint256 public settlementTimeout; // Time in seconds a party can take to accept or propose a settlement before being considered unresponsive.
     Transaction[] public transactions; // List of all created transactions.
-    mapping(uint256 => uint256) public disputeIDtoTransactionID; // Naps dispute ID to tx ID.
+    mapping(uint256 => uint256) public disputeIDtoTransactionID; // Maps dispute ID to tx ID.
     mapping(IERC20 => uint256) public amountCaps; // Caps the amount of the respective token for the Escrow transaction.
 
     // ************************************* //


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the clarity of comments in the `EscrowUniversal.sol` contract to enhance code readability.

### Detailed summary
- Updated comment for `disputeIDtoTransactionID` mapping from "Naps dispute ID to tx ID." to "Maps dispute ID to tx ID." for better clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in contract documentation comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->