### PR TITLE
chore: minor cleanup

### DIFF
--- a/contracts/scripts/generateDeploymentArtifact.sh
+++ b/contracts/scripts/generateDeploymentArtifact.sh
@@ -74,7 +74,3 @@ jq \
   --arg address "$address" \
   --argjson abi "$abi" \
   '{ "address": $address, "abi": $abi }' <<< '{}'
-
-
-# https://api.etherscan.io/v2/api?chainid=42161&module=contract&action=getabi&apikey=1W5G377DC58GS36T3BYIB9KCFVFCGQ216N&address=0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9
-


### PR DESCRIPTION
Minor cleanup before syncing dev with master.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes a commented-out URL from the `generateDeploymentArtifact.sh` script, which was likely used for fetching ABI data from Etherscan. 

### Detailed summary
- Removed a comment containing a URL for the Etherscan API that retrieves the ABI for a specific contract address.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor cleanup of script files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->