### PR TITLE
feat: etherscan links in timeline

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kleros/escrow-v2-subgraph",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "scripts": {
     "update:arbitrum-sepolia-devnet": "./scripts/update.sh arbitrumSepoliaDevnet arbitrum-sepolia",
@@ -15,7 +15,7 @@
     "deploy:arbitrum": "graph deploy escrow-v2-neo -l v$npm_package_version",
     "deploy-goldsky:arbitrum-sepolia-devnet": "goldsky subgraph deploy escrow-v2-devnet/v$npm_package_version --path .",
     "deploy-goldsky:arbitrum-sepolia": "goldsky subgraph deploy escrow-v2-testnet/v$npm_package_version --path .",
-    "deploy-goldsky:arbitrum": "goldsky subgraph deploy escrow-v2-mainnet/v$npm_package_version --path .",
+    "deploy-goldsky:arbitrum": "goldsky subgraph deploy escrow-v2-neo/v$npm_package_version --path .",
     "create-local": "graph create --node http://localhost:8020/ kleros/escrow-v2-local",
     "remove-local": "graph remove --node http://localhost:8020/ kleros/escrow-v2-local",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 kleros/escrow-v2-local --version-label v$(date +%s)",

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -65,6 +65,7 @@ type Payment @entity {
   amount: BigInt!
   party: Bytes!
   timestamp: BigInt
+  transactionHash: Bytes!
 }
 
 type HasToPayFee @entity {
@@ -72,6 +73,7 @@ type HasToPayFee @entity {
   escrow: Escrow!
   party: String
   timestamp: BigInt
+  transactionHash: Bytes!
 }
 
 type DisputeRequest @entity {
@@ -79,11 +81,13 @@ type DisputeRequest @entity {
   escrow: Escrow!
   timestamp: BigInt
   from: Bytes
+  transactionHash: Bytes!
 }
 
 type TransactionCreated @entity {
   id: ID!
   escrow: Escrow!
+  transactionHash: Bytes!
 }
 
 type TransactionResolved @entity {
@@ -91,6 +95,7 @@ type TransactionResolved @entity {
   escrow: Escrow!
   resolution: Int!
   timestamp: BigInt
+  transactionHash: Bytes!
 }
 
 type SettlementProposal @entity {
@@ -99,6 +104,7 @@ type SettlementProposal @entity {
   party: String
   amount: BigInt!
   timestamp: BigInt!
+  transactionHash: Bytes!
 }
 
 type EscrowParameters @entity {

--- a/subgraph/src/escrow.ts
+++ b/subgraph/src/escrow.ts
@@ -86,6 +86,7 @@ export function handlePayment(event: PaymentEvent): void {
   payment.amount = event.params._amount;
   payment.timestamp = event.block.timestamp;
   payment.party = Bytes.fromHexString(event.params._party.toHex());
+  payment.transactionHash = event.transaction.hash;
 
   payment.save();
 }
@@ -124,6 +125,7 @@ export function handleHasToPayFee(event: HasToPayFeeEvent): void {
   hasToPayFee.escrow = escrowId;
   hasToPayFee.party = partyValue.toString();
   hasToPayFee.timestamp = event.block.timestamp;
+  hasToPayFee.transactionHash = event.transaction.hash;
   hasToPayFee.save();
 
   escrow.save();
@@ -157,6 +159,7 @@ export function handleNativeTransactionCreated(event: NativeTransactionCreatedEv
   let transactionCreatedId = event.transaction.hash.toHex() + "-" + event.logIndex.toString();
   let transactionCreated = new TransactionCreated(transactionCreatedId);
   transactionCreated.escrow = escrowId;
+  transactionCreated.transactionHash = event.transaction.hash;
 
   transactionCreated.save();
 }
@@ -190,6 +193,7 @@ export function handleERC20TransactionCreated(event: ERC20TransactionCreatedEven
   let transactionCreatedId = event.transaction.hash.toHex() + "-" + event.logIndex.toString();
   let transactionCreated = new TransactionCreated(transactionCreatedId);
   transactionCreated.escrow = escrowId;
+  transactionCreated.transactionHash = event.transaction.hash;
 
   transactionCreated.save();
 }
@@ -207,6 +211,7 @@ export function handleTransactionResolved(event: TransactionResolvedEvent): void
   transactionResolved.escrow = escrowId;
   transactionResolved.resolution = event.params._resolution;
   transactionResolved.timestamp = event.block.timestamp;
+  transactionResolved.transactionHash = event.transaction.hash;
   transactionResolved.save();
 
   let buyerId = escrow.buyer.toHex();
@@ -257,6 +262,7 @@ export function handleDisputeRequest(event: DisputeRequestEvent): void {
   disputeRequest.escrow = escrow.id;
   disputeRequest.timestamp = event.block.timestamp;
   disputeRequest.from = Bytes.fromHexString(event.transaction.from.toHex());
+  disputeRequest.transactionHash = event.transaction.hash;
   disputeRequest.save();
 
   let buyer = getUser(escrow.buyer.toHex());
@@ -303,6 +309,7 @@ export function handleSettlementProposed(event: SettlementProposedEvent): void {
   proposal.party = partyValue;
   proposal.amount = event.params._amount;
   proposal.timestamp = event.block.timestamp;
+  proposal.transactionHash = event.transaction.hash;
 
   proposal.save();
   escrow.save();

--- a/web/src/components/PreviewCard/EscrowTimeline/index.tsx
+++ b/web/src/components/PreviewCard/EscrowTimeline/index.tsx
@@ -6,7 +6,8 @@ import { DisputeRequest, HasToPayFee, Payment, SettlementProposal, TransactionRe
 interface IEscrowTimeline {
   isPreview: boolean;
   transactionCreationTimestamp: number;
-  status: boolean;
+  transactionHash: string;
+  status: string;
   assetSymbol: string;
   isNativeTransaction: boolean;
   tokenDecimals?: number;
@@ -17,11 +18,14 @@ interface IEscrowTimeline {
   hasToPayFees: HasToPayFee[];
   disputeRequest: DisputeRequest;
   resolvedEvents: TransactionResolved[];
+  feeTimeout: number;
+  settlementTimeout: number;
 }
 
 const EscrowTimeline: React.FC<IEscrowTimeline> = ({
   isPreview,
   transactionCreationTimestamp,
+  transactionHash,
   status,
   assetSymbol,
   isNativeTransaction,
@@ -39,10 +43,10 @@ const EscrowTimeline: React.FC<IEscrowTimeline> = ({
   const items = useEscrowTimelineItems(
     isPreview,
     transactionCreationTimestamp,
+    transactionHash,
     status,
     assetSymbol,
     isNativeTransaction,
-    tokenDecimals,
     buyerAddress,
     sellerAddress,
     payments,
@@ -51,7 +55,8 @@ const EscrowTimeline: React.FC<IEscrowTimeline> = ({
     disputeRequest,
     resolvedEvents,
     feeTimeout,
-    settlementTimeout
+    settlementTimeout,
+    tokenDecimals,
   );
 
   return <CustomTimeline className="w-full" items={items} />;

--- a/web/src/components/PreviewCard/Header.tsx
+++ b/web/src/components/PreviewCard/Header.tsx
@@ -1,23 +1,18 @@
 import React from "react";
-import { SUPPORTED_CHAINS, DEFAULT_CHAIN } from "consts/chains";
 import { isUndefined } from "utils/index";
 import { mapStatusToEnum } from "utils/mapStatusToEnum";
 import StatusBanner from "../TransactionCard/StatusBanner";
-import EtherscanIcon from "svgs/icons/etherscan.svg";
 import Skeleton from "react-loading-skeleton";
+import { Statuses } from "~src/consts/statuses";
 
 interface IHeader {
   escrowType: string;
   escrowTitle?: string;
-  id: string;
   status: string;
-  transactionHash: string;
-  isCard: boolean;
 }
 
-const Header: React.FC<IHeader> = ({ escrowType, escrowTitle, id, status, transactionHash, isCard }) => {
-  const currentStatusEnum = mapStatusToEnum(status);
-  const etherscanUrl = `${SUPPORTED_CHAINS[DEFAULT_CHAIN].blockExplorers?.default.url}/tx/${transactionHash}`;
+const Header: React.FC<IHeader> = ({ escrowType, escrowTitle, status }) => {
+  const currentStatusEnum = mapStatusToEnum(status) ?? Statuses.inProgress;
 
   return (
     <div className="flex flex-wrap justify-between gap-3">
@@ -32,11 +27,6 @@ const Header: React.FC<IHeader> = ({ escrowType, escrowTitle, id, status, transa
         )}
       </div>
       <div className="flex items-center gap-4 lg:shrink-0 lg:gap-y-0 lg:gap-x-fluid-24-32-900">
-        {transactionHash ? (
-          <a href={etherscanUrl} target="_blank" rel="noreferrer">
-            <EtherscanIcon width={16} height={16} />
-          </a>
-        ) : null}
         <StatusBanner status={currentStatusEnum} isPreview={true} />
       </div>
     </div>

--- a/web/src/components/PreviewCard/index.tsx
+++ b/web/src/components/PreviewCard/index.tsx
@@ -66,7 +66,7 @@ const PreviewCard: React.FC<IPreviewCard> = ({
   arbitrationCost,
 }) => (
   <Card className={clsx("flex flex-col gap-4 lg:gap-6", "w-full h-auto p-4 pt-5 lg:p-8", isPreview && "pb-9")}>
-    <Header {...{ escrowType, escrowTitle, status, transactionHash, isCard: false }} />
+    <Header {...{ escrowType, escrowTitle, status }} />
     <div className="flex flex-col gap-6">
       <hr className={dividerStyle} />
       <TransactionInfo
@@ -98,6 +98,7 @@ const PreviewCard: React.FC<IPreviewCard> = ({
         isNativeTransaction,
         tokenDecimals,
         transactionCreationTimestamp,
+        transactionHash,
         buyerAddress,
         sellerAddress,
         payments,

--- a/web/src/hooks/queries/useTransactionsQuery.ts
+++ b/web/src/hooks/queries/useTransactionsQuery.ts
@@ -24,11 +24,13 @@ export const transactionFragment = graphql(`
       amount
       party
       timestamp
+      transactionHash
     }
     hasToPayFees {
       id
       party
       timestamp
+      transactionHash
     }
     createdEvents {
       id
@@ -37,12 +39,14 @@ export const transactionFragment = graphql(`
       id
       resolution
       timestamp
+      transactionHash
     }
     settlementProposals(orderBy: timestamp, orderDirection: asc) {
       id
       amount
       party
       timestamp
+      transactionHash
     }
     disputeRequest {
       id
@@ -51,6 +55,7 @@ export const transactionFragment = graphql(`
         id
       }
       timestamp
+      transactionHash
     }
   }
 `);

--- a/web/src/hooks/useEscrowTimelineItems.tsx
+++ b/web/src/hooks/useEscrowTimelineItems.tsx
@@ -59,7 +59,7 @@ function createTimelineItem(
     party: explorerUrl ? (
       <div className={cn("flex items-center", party ? "gap-x-2" : "")}>
         <span className="text-sm" style={{ color: themeColor }}>{party}</span>
-        <a href={explorerUrl} target="_blank" rel="noopener noreferrer">
+        <a href={explorerUrl} target="_blank" rel="noopener noreferrer" aria-label="View transaction on block explorer">
           <EtherscanIcon width={14} height={14} />
         </a>
       </div>

--- a/web/src/hooks/useEscrowTimelineItems.tsx
+++ b/web/src/hooks/useEscrowTimelineItems.tsx
@@ -6,8 +6,11 @@ import { resolutionToString } from "utils/resolutionToString";
 import { formatTimeoutDuration } from "utils/formatTimeoutDuration";
 import CheckCircleOutlineIcon from "components/StyledIcons/CheckCircleOutlineIcon";
 import LawBalanceIcon from "components/StyledIcons/LawBalanceIcon";
+import EtherscanIcon from "svgs/icons/etherscan.svg";
+import { SUPPORTED_CHAINS, DEFAULT_CHAIN } from "consts/chains";
 import { DisputeRequest, HasToPayFee, Payment, SettlementProposal, TransactionResolved } from "src/graphql/graphql";
 import Skeleton from "react-loading-skeleton";
+import { cn } from "~src/utils";
 
 type Variant = "primaryBlue" | "secondaryBlue" | "warning" | "secondaryPurple" | "success";
 const variantToCssVar: Record<Variant, string> = {
@@ -19,8 +22,8 @@ const variantToCssVar: Record<Variant, string> = {
 };
 
 interface TimelineItem {
-  title: string;
-  party?: string;
+  title: React.ReactNode;
+  party?: React.ReactNode;
   subtitle: string;
   rightSided: boolean;
   variant: string;
@@ -35,19 +38,37 @@ function getThemeColor(variant: Variant): string {
   return getComputedStyle(document.documentElement).getPropertyValue(variantToCssVar[variant]).trim();
 }
 
+function getExplorerLink(transactionHash?: string): string | null {
+  if (!transactionHash) return null;
+  return `${SUPPORTED_CHAINS[DEFAULT_CHAIN].blockExplorers?.default.url}/tx/${transactionHash}`;
+}
+
 function createTimelineItem(
   formattedDate: string,
-  title: string,
-  party: string,
+  title: React.ReactNode,
+  party: React.ReactNode,
   variant: Variant,
+  transactionHash?: string,
   Icon?: React.ElementType
 ): TimelineItem {
+  const explorerUrl = getExplorerLink(transactionHash);
+  const themeColor = getThemeColor(variant);
+
   return {
     title,
-    party,
+    party: explorerUrl ? (
+      <div className={cn("flex items-center", party ? "gap-x-2" : "")}>
+        <span className="text-sm" style={{ color: themeColor }}>{party}</span>
+        <a href={explorerUrl} target="_blank" rel="noopener noreferrer">
+          <EtherscanIcon width={14} height={14} />
+        </a>
+      </div>
+    ) : (
+      party
+    ),
     subtitle: formattedDate,
     rightSided: true,
-    variant: getThemeColor(variant),
+    variant: themeColor,
     ...(Icon && { Icon }),
   };
 }
@@ -55,10 +76,10 @@ function createTimelineItem(
 const useEscrowTimelineItems = (
   isPreview: boolean,
   transactionCreationTimestamp: number,
+  escrowTransactionHash: string,
   status: string,
   assetSymbol: string,
   isNativeTransaction: boolean,
-  tokenDecimals?: number,
   buyer: string,
   seller: string,
   payments: Payment[],
@@ -67,7 +88,8 @@ const useEscrowTimelineItems = (
   disputeRequest: DisputeRequest | null,
   resolvedEvents: TransactionResolved[],
   feeTimeout: number,
-  settlementTimeout: number
+  settlementTimeout: number,
+  tokenDecimals?: number
 ): TimelineItem[] => {
   const [currentTime, setCurrentTime] = useState<number>(Math.floor(Date.now() / 1000));
 
@@ -82,7 +104,7 @@ const useEscrowTimelineItems = (
     const formattedCreationDate = isPreview
       ? getFormattedDate(new Date())
       : getFormattedDate(new Date(transactionCreationTimestamp * 1000));
-    timelineItems.push(createTimelineItem(formattedCreationDate, "Escrow created", "", "primaryBlue"));
+    timelineItems.push(createTimelineItem(formattedCreationDate, "Escrow created", "", "primaryBlue", escrowTransactionHash));
 
     if (!isPreview) {
       payments?.forEach((payment) => {
@@ -98,7 +120,7 @@ const useEscrowTimelineItems = (
           </>
         );
 
-        timelineItems.push(createTimelineItem(formattedDate, title, "", "secondaryBlue"));
+        timelineItems.push(createTimelineItem(formattedDate, title, "", "secondaryBlue", payment.transactionHash));
       });
 
       settlementProposals?.forEach((proposal, index) => {
@@ -117,9 +139,8 @@ const useEscrowTimelineItems = (
         } else if (hasToPayFees.length > 0 || !isLatestProposal) {
           subtitle = "Proposal refused";
         } else {
-          subtitle = `Waiting ${
-            proposal.party === "1" ? "Seller's" : "Buyer's"
-          } answer [Timeout: ${formatTimeoutDuration(timeLeft)}]`;
+          subtitle = `Waiting ${proposal.party === "1" ? "Seller's" : "Buyer's"
+            } answer [Timeout: ${formatTimeoutDuration(timeLeft)}]`;
         }
 
         const formattedAmount = isNativeTransaction
@@ -131,7 +152,7 @@ const useEscrowTimelineItems = (
             {assetSymbol ? assetSymbol : <Skeleton className="z-0" width={30} />}
           </>
         );
-        timelineItems.push(createTimelineItem(formattedDate, title, subtitle, "warning"));
+        timelineItems.push(createTimelineItem(formattedDate, title, subtitle, "warning", proposal.transactionHash));
       });
 
       hasToPayFees?.forEach((fee) => {
@@ -146,7 +167,7 @@ const useEscrowTimelineItems = (
           ? "Arbitration fees deposited"
           : `${fee.party === "2" ? "Seller" : "Buyer"}${timeoutCountdownMessage}`;
 
-        timelineItems.push(createTimelineItem(formattedDate, title, party, "secondaryPurple"));
+        timelineItems.push(createTimelineItem(formattedDate, title, party, "secondaryPurple", fee.transactionHash));
       });
 
       if (disputeRequest) {
@@ -157,6 +178,7 @@ const useEscrowTimelineItems = (
             "Dispute created",
             `Case #${disputeRequest.id}`,
             "secondaryPurple",
+            disputeRequest.transactionHash,
             LawBalanceIcon
           )
         );
@@ -172,6 +194,7 @@ const useEscrowTimelineItems = (
               "Concluded",
               resolutionToString(resolutionEvent.resolution),
               "success",
+              resolutionEvent.transactionHash,
               CheckCircleOutlineIcon
             )
           );
@@ -183,6 +206,7 @@ const useEscrowTimelineItems = (
   }, [
     isPreview,
     transactionCreationTimestamp,
+    escrowTransactionHash,
     status,
     payments,
     settlementProposals,


### PR DESCRIPTION
Resolves #151.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `transactionHash` field across multiple entities and components in the escrow system, enhancing transaction tracking and display functionalities.

### Detailed summary
- Added `transactionHash` field in various GraphQL entities (`TransactionCreated`, `SettlementProposal`, etc.).
- Updated `PreviewCard` and `EscrowTimeline` components to use `transactionHash`.
- Modified `Header` component to remove `transactionHash`.
- Enhanced `useEscrowTimelineItems` to include `transactionHash` in timeline items.
- Updated handling of events in `subgraph/src/escrow.ts` to save `transactionHash`.
- Updated package version in `subgraph/package.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction hashes are now recorded and shown for payments, fees, disputes, proposals and resolutions; timeline entries include clickable on-chain explorer links.

* **UI Changes**
  * Timeline displays additional timeout metadata.
  * Header no longer shows an external explorer link.

* **Chores**
  * Package version bumped to 2.2.2.
  * Deployment target updated for Arbitrum mainnet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->