### PR TITLE
fix(web): security-fixes

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -66,6 +66,7 @@
     "vite-tsconfig-paths": "^4.3.2"
   },
   "dependencies": {
+    "@braintree/sanitize-url": "^7.1.2",
     "@kleros/kleros-app": "^3.0.1",
     "@kleros/ui-components-library": "^3.8.0",
     "@mdxeditor/editor": "^3.45.0",

--- a/web/src/components/MarkdownRenderer.tsx
+++ b/web/src/components/MarkdownRenderer.tsx
@@ -147,7 +147,7 @@ const MarkdownRenderer: React.FC<IMarkdownRenderer> = ({ content, className }) =
                   "address",
                 ],
                 attributes: {
-                  ...(defaultSchema?.attributes ?? []),
+                  ...(defaultSchema?.attributes ?? {}),
                   a: ["href", "title", "target", "rel"],
                   img: ["src", "alt", "title", "width", "height"],
                   th: ["scope", "colspan", "rowspan"],

--- a/web/src/components/MarkdownRenderer.tsx
+++ b/web/src/components/MarkdownRenderer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
-import rehypeSanitize from "rehype-sanitize";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 
 import { isExternalLink } from "utils/linkUtils";
@@ -88,6 +88,7 @@ const MarkdownRenderer: React.FC<IMarkdownRenderer> = ({ content, className }) =
             [
               rehypeSanitize,
               {
+                ...defaultSchema,
                 tagNames: [
                   "p",
                   "br",
@@ -101,7 +102,6 @@ const MarkdownRenderer: React.FC<IMarkdownRenderer> = ({ content, className }) =
                   "ul",
                   "ol",
                   "li",
-                  "input",
                   "strong",
                   "b",
                   "em",
@@ -147,10 +147,9 @@ const MarkdownRenderer: React.FC<IMarkdownRenderer> = ({ content, className }) =
                   "address",
                 ],
                 attributes: {
-                  "*": ["className", "id", "style"],
+                  ...(defaultSchema?.attributes ?? []),
                   a: ["href", "title", "target", "rel"],
                   img: ["src", "alt", "title", "width", "height"],
-                  input: ["type", "checked", "disabled"],
                   th: ["scope", "colspan", "rowspan"],
                   td: ["colspan", "rowspan"],
                   details: ["open"],

--- a/web/src/pages/AttachmentDisplay/index.tsx
+++ b/web/src/pages/AttachmentDisplay/index.tsx
@@ -7,6 +7,8 @@ import NewTabIcon from "svgs/icons/new-tab.svg";
 import Loader from "components/Loader";
 import ScrollTop from "components/ScrollTop";
 
+import { getAllowedAttachmentUrl } from "utils/urlValidation";
+
 import Header from "./Header";
 import clsx from "clsx";
 
@@ -18,6 +20,7 @@ const AttachmentDisplay: React.FC = () => {
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const url = searchParams.get("url");
+  const safeUrl = url ? getAllowedAttachmentUrl(url) : null;
 
   return (
     <div
@@ -28,11 +31,11 @@ const AttachmentDisplay: React.FC = () => {
       )}
     >
       <Header />
-      {url ? (
+      {safeUrl ? (
         <>
           <Link
             className="flex gap-2 items-center self-end mb-2 hover:underline"
-            to={url}
+            to={safeUrl}
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -53,7 +56,7 @@ const AttachmentDisplay: React.FC = () => {
               * - we are already in the Attachments page but want to see a different document.
               */
             }
-            <FileViewer key={location.key} url={url} />
+            <FileViewer key={location.key} url={safeUrl} />
           </Suspense>
         </>
       ) : null}

--- a/web/src/pages/AttachmentDisplay/index.tsx
+++ b/web/src/pages/AttachmentDisplay/index.tsx
@@ -12,9 +12,7 @@ import { getAllowedAttachmentUrl } from "utils/urlValidation";
 import Header from "./Header";
 import clsx from "clsx";
 
-const FileViewer = lazy(() =>
-  import("@kleros/ui-components-library").then((m) => ({ default: m.FileViewer }))
-);
+const FileViewer = lazy(() => import("@kleros/ui-components-library").then((m) => ({ default: m.FileViewer })));
 
 const AttachmentDisplay: React.FC = () => {
   const location = useLocation();
@@ -48,18 +46,32 @@ const AttachmentDisplay: React.FC = () => {
               </div>
             }
           >
-            {
-              /* 
-              * Use the location.key as the key to force a re-render. 
-              * Without this, the FileViewer does not display documents if:
-              * - the same document is selected twice in a row from the Policies dropdown menu by mistake.
-              * - we are already in the Attachments page but want to see a different document.
-              */
-            }
+            {/*
+             * Use the location.key as the key to force a re-render.
+             * Without this, the FileViewer does not display documents if:
+             * - the same document is selected twice in a row from the Policies dropdown menu by mistake.
+             * - we are already in the Attachments page but want to see a different document.
+             */}
             <FileViewer key={location.key} url={safeUrl} />
           </Suspense>
         </>
       ) : null}
+
+      {url && !safeUrl ? (
+        <div className="flex flex-col gap-2 w-full">
+          <p className="text-klerosUIComponentsSecondaryText text-base">This link cannot be previewed here.</p>
+          <div
+            className={clsx(
+              "bg-klerosUIComponentsLightBackground border rounded-sm border-klerosUIComponentsStroke",
+              "text-sm font-mono text-klerosUIComponentsPrimaryText break-all",
+              "w-full py-2 px-3"
+            )}
+          >
+            {url}
+          </div>
+        </div>
+      ) : null}
+
       <ScrollTop />
     </div>
   );

--- a/web/src/utils/urlValidation.ts
+++ b/web/src/utils/urlValidation.ts
@@ -1,46 +1,36 @@
-const DANGEROUS_PROTOCOLS = ["javascript:", "vbscript:", "file:", "about:", "blob:", "filesystem:"];
+import { sanitizeUrl } from "@braintree/sanitize-url";
 
-const ALLOWED_PROTOCOLS = ["http:", "https:", "mailto:", "tel:", "ftp:"];
+import { IPFS_GATEWAY } from "consts/index";
 
-const ALLOWED_DATA_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+const BLANK_URL = "about:blank";
 
-const isValidDataUri = (url: string): boolean => {
-  const dataUriRegex = /^data:([^;,]+)(;base64)?,/i;
-  const match = url.match(dataUriRegex);
+const getGatewayOrigin = () => new URL(IPFS_GATEWAY).origin;
 
-  if (!match) {
-    return false;
+export const sanitizeHref = (url: string) => {
+  if (!url || typeof url !== "string") {
+    return "";
   }
 
-  const mimeType = match[1].toLowerCase();
-  return ALLOWED_DATA_TYPES.includes(mimeType);
+  const sanitized = sanitizeUrl(url.trim());
+  return sanitized === BLANK_URL ? "" : sanitized;
 };
 
-export const isValidUrl = (url: string): boolean => {
-  if (!url || typeof url !== "string") {
-    return false;
-  }
+export const isValidUrl = (url: string) => sanitizeHref(url) !== "";
 
-  const trimmedUrl = url.trim().toLowerCase();
-
-  if (trimmedUrl.length === 0) {
-    return false;
-  }
-
-  if (trimmedUrl.startsWith("data:")) {
-    return isValidDataUri(trimmedUrl);
-  }
-
-  for (const protocol of DANGEROUS_PROTOCOLS) {
-    if (trimmedUrl.startsWith(protocol)) {
-      return false;
-    }
+export const getAllowedAttachmentUrl = (url: string) => {
+  const safe = sanitizeHref(url);
+  if (!safe) {
+    return undefined;
   }
 
   try {
-    const urlObj = new URL(url);
-    return ALLOWED_PROTOCOLS.includes(urlObj.protocol);
+    const parsed = new URL(safe);
+    if (parsed.protocol !== "https:" || parsed.origin !== getGatewayOrigin() || !parsed.pathname.startsWith("/ipfs/")) {
+      return undefined;
+    }
+
+    return parsed.href;
   } catch {
-    return false;
+    return undefined;
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,6 +1964,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@braintree/sanitize-url@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "@braintree/sanitize-url@npm:7.1.2"
+  checksum: 10/d9626ff8f8eb5e192cd055e6e743449c21102c76bb59e405b7028fe56230fa080bfcc80dfb1e21850a6876e75adda9f7b3c888cf0685942bb74da4d2866d6ec3
+  languageName: node
+  linkType: hard
+
 "@chainlink/contracts@npm:^1.4.0":
   version: 1.4.0
   resolution: "@chainlink/contracts@npm:1.4.0"
@@ -5685,6 +5692,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kleros/escrow-v2-web@workspace:web"
   dependencies:
+    "@braintree/sanitize-url": "npm:^7.1.2"
     "@graphql-codegen/cli": "npm:^4.0.1"
     "@graphql-codegen/client-preset": "npm:^4.6.2"
     "@kleros/kleros-app": "npm:^3.0.1"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing URL sanitization and validation within the application by adding the `@braintree/sanitize-url` package, modifying components to use this new sanitization method, and updating the `AttachmentDisplay` logic to handle safe URLs.

### Detailed summary
- Added `@braintree/sanitize-url` dependency in `package.json`.
- Updated `MarkdownRenderer` to use `rehype-sanitize` with `defaultSchema`.
- Refactored `urlValidation.ts` to incorporate `sanitizeUrl` and define `sanitizeHref`.
- Implemented `getAllowedAttachmentUrl` to ensure safe URL handling.
- Adjusted `AttachmentDisplay` component to use sanitized URLs.
- Enhanced error handling for unsafe URLs in the UI.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachment links are now strictly validated: only safe HTTPS IPFS gateway links can be previewed; unsafe links show a clear “This link cannot be previewed here.” message.
  * Markdown rendering tightened: unsafe elements removed and allowed attributes restricted to reduce injection and preview risks.

* **Chores**
  * Added a URL-sanitization dependency to improve input safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->