### PR TITLE
chore: remove unused networks

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -76,7 +76,6 @@ The ones below are optional:
 
 - `ETHERSCAN_API_KEY`: to verify the source of the newly deployed contracts on **Etherscan**.
 - `ARBISCAN_API_KEY`: to verify the source of the newly deployed contracts on **Arbitrum**.
-- `GNOSISSCAN_API_KEY`: to verify the source of the newly deployed contracts on **Gnosis chain**.
 
 #### 1. Deploy to a Local Network
 
@@ -162,10 +161,10 @@ yarn sourcify --network arbitrumSepolia
 scripts/generateDeploymentArtifact.sh <network> <address>
 ```
 
-#### Example: WETH on Gnosis chain
+#### Example: WETH on Arbitrum
 
 ```bash
-scripts/generateDeploymentArtifact.sh gnosischain 0xf8d1677c8a0c961938bf2f9adc3f3cfda759a9d9 > deployments/gnosischain/WETH.json
+scripts/generateDeploymentArtifact.sh arbitrum 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1 > deployments/arbitrum/WETH.json
 ```
 
 ### Push the contracts to a Tenderly project

--- a/contracts/README.md.template
+++ b/contracts/README.md.template
@@ -62,7 +62,6 @@ The ones below are optional:
 
 - `ETHERSCAN_API_KEY`: to verify the source of the newly deployed contracts on **Etherscan**.
 - `ARBISCAN_API_KEY`: to verify the source of the newly deployed contracts on **Arbitrum**.
-- `GNOSISSCAN_API_KEY`: to verify the source of the newly deployed contracts on **Gnosis chain**.
 
 #### 1. Deploy to a Local Network
 
@@ -148,10 +147,10 @@ yarn sourcify --network arbitrumSepolia
 scripts/generateDeploymentArtifact.sh <network> <address>
 ```
 
-#### Example: WETH on Gnosis chain
+#### Example: WETH on Arbitrum
 
 ```bash
-scripts/generateDeploymentArtifact.sh gnosischain 0xf8d1677c8a0c961938bf2f9adc3f3cfda759a9d9 > deployments/gnosischain/WETH.json
+scripts/generateDeploymentArtifact.sh arbitrum 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1 > deployments/arbitrum/WETH.json
 ```
 
 ### Push the contracts to a Tenderly project

--- a/contracts/deploy/utils/index.ts
+++ b/contracts/deploy/utils/index.ts
@@ -15,8 +15,6 @@ export enum HomeChains {
 export enum ForeignChains {
   ETHEREUM_MAINNET = 1,
   ETHEREUM_SEPOLIA = 11155111,
-  GNOSIS_MAINNET = 100,
-  GNOSIS_CHIADO = 10200,
   HARDHAT = HardhatChain.HARDHAT,
 }
 

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -129,19 +129,6 @@ const config: HardhatUserConfig = {
       saveDeployments: true,
       tags: ["production", "foreign", "layer1"],
     },
-    gnosischain: {
-      chainId: 100,
-      url: `https://rpc.gnosis.gateway.fm`,
-      accounts,
-      live: true,
-      saveDeployments: true,
-      tags: ["production", "foreign", "layer1"],
-      verify: {
-        etherscan: {
-          apiKey: process.env.GNOSISSCAN_API_KEY,
-        },
-      },
-    },
   },
   namedAccounts: {
     deployer: {

--- a/contracts/scripts/exportDeployments.sh
+++ b/contracts/scripts/exportDeployments.sh
@@ -12,7 +12,5 @@ exportJson arbitrumSepolia
 exportJson arbitrumSepoliaDevnet
 exportJson sepolia
 exportJson sepoliaDevnet
-exportJson chiado
-exportJson chiadoDevnet
 exportJson arbitrum
 exportJson mainnet

--- a/contracts/scripts/generateDeploymentArtifact.sh
+++ b/contracts/scripts/generateDeploymentArtifact.sh
@@ -13,22 +13,10 @@ address=$2
 
 # Limitation: proxy contracts will return the proxy's ABI, not its implementation's ABI.
 # Workaround: query the address of the implementation, and manually change the address to the proxy's in the artifact.
-# Example: WETH on Gnosis chain, https://gnosisscan.io/address/0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1#code
 
 url="https://api.etherscan.io/v2"
 
 case $network in
-gnosischain)
-  chainId=100
-  apiKey=$($SCRIPT_DIR/dotenv.sh ETHERSCAN_API_KEY_FIX)
-  ;;
-chiado)
-  # Warning: these are distinct instances!
-  # https://blockscout.com/gnosis/chiado/api-docs
-  # https://blockscout.chiadochain.net
-  url="https://blockscout.com/gnosis/chiado"
-  apiKey=""
-  ;;
 arbitrum)
   chainId=42161
   apiKey=$($SCRIPT_DIR/dotenv.sh ETHERSCAN_API_KEY_FIX)

--- a/contracts/wagmi.config.devnet.ts
+++ b/contracts/wagmi.config.devnet.ts
@@ -7,10 +7,6 @@ const getConfig = async (): Promise<Config> => {
   arbitrumSepoliaContracts.forEach((c) => console.log("✔ Found arbitrumSepolia artifact: %s", c.name));
   let contracts = arbitrumSepoliaContracts;
 
-  const chiadoContracts = await readArtifacts("gnosisChiado", "chiadoDevnet"); // renaming the Hardhat network improves this but breaks many other scripts
-  chiadoContracts.forEach((c) => console.log("✔ Found chiado artifact: %s", c.name));
-  contracts = merge(contracts, chiadoContracts);
-
   const sepoliaContracts = await readArtifacts("sepolia", "sepoliaDevnet");
   sepoliaContracts.forEach((c) => console.log("✔ Found sepolia artifact: %s", c.name));
   contracts = merge(contracts, sepoliaContracts);

--- a/contracts/wagmi.config.mainnet.ts
+++ b/contracts/wagmi.config.mainnet.ts
@@ -7,10 +7,6 @@ const getConfig = async (): Promise<Config> => {
   arbitrumContracts.forEach((c) => console.log("✔ Found arbitrum artifact: %s", c.name));
   let contracts = arbitrumContracts;
 
-  const gnosisContracts = await readArtifacts("gnosis", "gnosischain");
-  gnosisContracts.forEach((c) => console.log("✔ Found gnosis artifact: %s", c.name));
-  contracts = merge(contracts, gnosisContracts);
-
   const mainnetContracts = await readArtifacts("mainnet");
   mainnetContracts.forEach((c) => console.log("✔ Found mainnet artifact: %s", c.name));
   contracts = merge(contracts, mainnetContracts);

--- a/contracts/wagmi.config.testnet.ts
+++ b/contracts/wagmi.config.testnet.ts
@@ -7,10 +7,6 @@ const getConfig = async (): Promise<Config> => {
   arbitrumSepoliaContracts.forEach((c) => console.log("✔ Found arbitrumSepolia artifact: %s", c.name));
   let contracts = arbitrumSepoliaContracts;
 
-  const chiadoContracts = await readArtifacts("gnosisChiado", "chiado"); // renaming the Hardhat network improves this but breaks many other scripts
-  chiadoContracts.forEach((c) => console.log("✔ Found chiado artifact: %s", c.name));
-  contracts = merge(contracts, chiadoContracts);
-
   const sepoliaContracts = await readArtifacts("sepolia");
   sepoliaContracts.forEach((c) => console.log("✔ Found sepolia artifact: %s", c.name));
   contracts = merge(contracts, sepoliaContracts);

--- a/web/src/consts/chains.ts
+++ b/web/src/consts/chains.ts
@@ -1,5 +1,5 @@
 import { type Chain, extractChain } from "viem";
-import { arbitrum, mainnet, arbitrumSepolia, gnosis, gnosisChiado, type AppKitNetwork } from "@reown/appkit/networks";
+import { arbitrum, mainnet, arbitrumSepolia, type AppKitNetwork } from "@reown/appkit/networks";
 
 import { isProductionDeployment } from "./index";
 
@@ -12,7 +12,6 @@ export const SUPPORTED_CHAINS: Record<number, AppKitNetwork> = {
 
 // Read Only
 export const QUERY_CHAINS: Record<number, AppKitNetwork> = {
-  [isProductionDeployment() ? gnosis.id : gnosisChiado.id]: isProductionDeployment() ? gnosis : gnosisChiado,
   [mainnet.id]: mainnet,
 };
 

--- a/web/src/context/Web3Provider.tsx
+++ b/web/src/context/Web3Provider.tsx
@@ -1,15 +1,7 @@
 import React from "react";
 
 import { fallback, http, WagmiProvider, webSocket } from "wagmi";
-import {
-  mainnet,
-  arbitrumSepolia,
-  gnosisChiado,
-  type AppKitNetwork,
-  arbitrum,
-  sepolia,
-  gnosis,
-} from "@reown/appkit/networks";
+import { mainnet, arbitrumSepolia, type AppKitNetwork, arbitrum, sepolia } from "@reown/appkit/networks";
 import { createAppKit } from "@reown/appkit/react";
 import { WagmiAdapter } from "@reown/appkit-adapter-wagmi";
 import { isProductionDeployment } from "consts/index";
@@ -28,8 +20,6 @@ const alchemyToViemChain: Record<number, string> = {
   [arbitrum.id]: "arb-mainnet",
   [mainnet.id]: "eth-mainnet",
   [sepolia.id]: "eth-sepolia",
-  [gnosis.id]: "gnosis-mainnet",
-  [gnosisChiado.id]: "gnosis-chiado",
 };
 
 type AlchemyProtocol = "https" | "wss";
@@ -54,16 +44,11 @@ export const getDefaultChainRpcUrl = (protocol: AlchemyProtocol) => {
 export const getTransports = () => {
   const alchemyTransport = (chain: AppKitNetwork) =>
     fallback([http(alchemyURL("https", chain.id)), webSocket(alchemyURL("wss", chain.id))]);
-  const defaultTransport = (chain: AppKitNetwork) =>
-    fallback([http(chain.rpcUrls.default?.http?.[0]), webSocket(chain.rpcUrls.default?.webSocket?.[0])]);
 
   return {
     [isProduction ? arbitrum.id : arbitrumSepolia.id]: isProduction
       ? alchemyTransport(arbitrum)
       : alchemyTransport(arbitrumSepolia),
-    [isProduction ? gnosis.id : gnosisChiado.id]: isProduction
-      ? defaultTransport(gnosis)
-      : defaultTransport(gnosisChiado),
     [mainnet.id]: alchemyTransport(mainnet), // Always enabled for ENS resolution
   };
 };


### PR DESCRIPTION
Resolves #177.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on the removal of references to the `Gnosis` and `Chiado` networks across multiple files, streamlining the codebase to exclude these networks while retaining support for `Ethereum`, `Arbitrum`, and `Sepolia`.

### Detailed summary
- Removed `Gnosis` and `Chiado` network constants from `contracts/deploy/utils/index.ts`.
- Eliminated `chiado` and `chiadoDevnet` exports in `contracts/scripts/exportDeployments.sh`.
- Deleted `gnosischain` configuration from `contracts/hardhat.config.ts`.
- Removed `gnosisContracts` and related merging logic in `contracts/wagmi.config.mainnet.ts`.
- Excluded `chiadoContracts` from both `contracts/wagmi.config.testnet.ts` and `contracts/wagmi.config.devnet.ts`.
- Updated `SUPPORTED_CHAINS` in `web/src/consts/chains.ts` to remove `Gnosis` references.
- Adjusted deployment artifact generation scripts to remove `Gnosis` related comments and examples in `contracts/scripts/generateDeploymentArtifact.sh`.
- Removed `GNOSISSCAN_API_KEY` references from `contracts/README.md` and `contracts/README.md.template`.
- Cleaned up imports in `web/src/context/Web3Provider.tsx` to exclude `Gnosis` and `Chiado`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated deployment instructions and artifact-generation examples to use Arbitrum.
  - Removed GnosisScan API key guidance.

- **Changes**
  - Removed Gnosis and Chiado network support from deployment, contract configuration, wallet connectivity, and chain selection.
  - Added Hardhat as a supported deployment environment.
  - Deployment exports and generated contract configurations now focus on Ethereum, Arbitrum, and supported testnets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->