### PR TITLE
feat: add fallback rpc system

### DIFF
--- a/web/src/context/Web3Provider.tsx
+++ b/web/src/context/Web3Provider.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { fallback, http, WagmiProvider, webSocket } from "wagmi";
-import { mainnet, arbitrumSepolia, type AppKitNetwork, arbitrum, sepolia } from "@reown/appkit/networks";
+import { mainnet, arbitrumSepolia, type AppKitNetwork, arbitrum } from "@reown/appkit/networks";
 import { createAppKit } from "@reown/appkit/react";
 import { WagmiAdapter } from "@reown/appkit-adapter-wagmi";
 import { isProductionDeployment } from "consts/index";
@@ -12,6 +12,8 @@ if (!alchemyApiKey) {
   throw new Error("Alchemy API key is not set in ALCHEMY_API_KEY environment variable.");
 }
 
+export const infuraApiKey = import.meta.env.INFURA_API_KEY ?? "";
+
 const isProduction = isProductionDeployment();
 
 // https://github.com/alchemyplatform/alchemy-sdk-js/blob/c4440cb/src/types/types.ts#L98-L153
@@ -19,7 +21,6 @@ const alchemyToViemChain: Record<number, string> = {
   [arbitrumSepolia.id]: "arb-sepolia",
   [arbitrum.id]: "arb-mainnet",
   [mainnet.id]: "eth-mainnet",
-  [sepolia.id]: "eth-sepolia",
 };
 
 type AlchemyProtocol = "https" | "wss";
@@ -33,6 +34,21 @@ function alchemyURL(protocol: AlchemyProtocol, chainId: number | string): string
   return `${protocol}://${network}.g.alchemy.com/v2/${alchemyApiKey}`;
 }
 
+function infuraURL(chainId: number | string): string | undefined {
+  const network = infuraToViemChain[chainId];
+  if (!infuraApiKey || !network) {
+    return undefined;
+  }
+  return `https://${network}.infura.io/v3/${infuraApiKey}`;
+}
+
+// https://docs.infura.io/get-started/endpoints/
+const infuraToViemChain: Record<number, string> = {
+  [arbitrumSepolia.id]: "arbitrum-sepolia",
+  [arbitrum.id]: "arbitrum-mainnet",
+  [mainnet.id]: "mainnet",
+};
+
 export const getChainRpcUrl = (protocol: AlchemyProtocol, chainId: number | string) => {
   return alchemyURL(protocol, chainId);
 };
@@ -41,20 +57,21 @@ export const getDefaultChainRpcUrl = (protocol: AlchemyProtocol) => {
   return getChainRpcUrl(protocol, DEFAULT_CHAIN);
 };
 
-export const getTransports = () => {
-  const alchemyTransport = (chain: AppKitNetwork) =>
-    fallback([http(alchemyURL("https", chain.id)), webSocket(alchemyURL("wss", chain.id))]);
+const buildTransport = (chain: AppKitNetwork) => {
+  const fallbackURL = infuraURL(chain.id);
+  return fallback([
+    http(alchemyURL("https", chain.id)),
+    ...(fallbackURL ? [http(fallbackURL)] : []),
+    webSocket(alchemyURL("wss", chain.id)),
+  ]);
+};
 
-  return {
-    [isProduction ? arbitrum.id : arbitrumSepolia.id]: isProduction
-      ? alchemyTransport(arbitrum)
-      : alchemyTransport(arbitrumSepolia),
-    [mainnet.id]: alchemyTransport(mainnet), // Always enabled for ENS resolution
-  };
+const transports = {
+  [isProduction ? arbitrum.id : arbitrumSepolia.id]: buildTransport(isProduction ? arbitrum : arbitrumSepolia),
+  [mainnet.id]: buildTransport(mainnet), // Always enabled for ENS resolution
 };
 
 const chains = ALL_CHAINS as [AppKitNetwork, ...AppKitNetwork[]];
-const transports = getTransports();
 
 const projectId = import.meta.env.WALLETCONNECT_PROJECT_ID;
 if (!projectId) {
@@ -66,6 +83,8 @@ const wagmiAdapter = new WagmiAdapter({
   projectId,
   transports,
 });
+
+export const wagmiConfig = wagmiAdapter.wagmiConfig;
 
 createAppKit({
   adapters: [wagmiAdapter],

--- a/web/src/env.d.ts
+++ b/web/src/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
     ALCHEMY_API_KEY: string;
+    INFURA_API_KEY?: string; //optional, fallback RPC
     WALLETCONNECT_PROJECT_ID: string;
   }
   

--- a/web/src/hooks/useTokenMetadata.ts
+++ b/web/src/hooks/useTokenMetadata.ts
@@ -3,6 +3,7 @@ import { Alchemy, TokenMetadataResponse } from "alchemy-sdk";
 
 import { DEFAULT_CHAIN } from "consts/chains";
 import { alchemyConfig } from "utils/alchemyConfig";
+import { fetchOnchainTokenMetadata } from "utils/fetchOnchainTokenMetadata";
 
 type TokenMetadataWithOptionalDecimals = Omit<TokenMetadataResponse, "decimals"> & {
   decimals?: number;
@@ -19,13 +20,27 @@ export const useTokenMetadata = (tokenAddress: TokenAddress) => {
       const alchemy = new Alchemy(alchemyConfig(DEFAULT_CHAIN));
       try {
         const metadata = await alchemy.core.getTokenMetadata(tokenAddress);
+
+        //Means alchemy knows nothing about the token, so we throw to try the contract directly.
+        if (!metadata.name && !metadata.symbol) {
+          throw new Error("No token metadata returned by alchemy");
+        }
+
         setTokenMetadata({
           ...metadata,
           decimals: metadata.decimals ?? undefined, //Set undefined if null to facilitate checks in the UI
         });
       } catch (error) {
-        console.error("Error fetching token metadata:", error);
-        setTokenMetadata(null);
+        const onchainMetadata = await fetchOnchainTokenMetadata(tokenAddress as `0x${string}`, DEFAULT_CHAIN).catch(
+          () => null
+        );
+
+        if (onchainMetadata) {
+          setTokenMetadata({ ...onchainMetadata, logo: null });
+        } else {
+          console.error("Error fetching token metadata:", error);
+          setTokenMetadata(null);
+        }
       }
     };
 

--- a/web/src/hooks/useTokenMetadata.ts
+++ b/web/src/hooks/useTokenMetadata.ts
@@ -21,8 +21,8 @@ export const useTokenMetadata = (tokenAddress: TokenAddress) => {
       try {
         const metadata = await alchemy.core.getTokenMetadata(tokenAddress);
 
-        //Means alchemy knows nothing about the token, so we throw to try the contract directly.
-        if (!metadata.name && !metadata.symbol) {
+        //Means alchemy metadata is missing or incomplete, so we throw to try the contract directly.
+        if (!metadata.name || !metadata.symbol) {
           throw new Error("No token metadata returned by alchemy");
         }
 

--- a/web/src/utils/fetchOnchainTokenMetadata.ts
+++ b/web/src/utils/fetchOnchainTokenMetadata.ts
@@ -1,0 +1,28 @@
+import { erc20Abi } from "viem";
+import { multicall } from "wagmi/actions";
+import { wagmiConfig } from "context/Web3Provider";
+
+type SupportedChainId = (typeof wagmiConfig)["chains"][number]["id"];
+
+//Fallback for when alchemy sdk fails or knows nothing about the token.
+export const fetchOnchainTokenMetadata = async (tokenAddress: `0x${string}`, chainId: number) => {
+  const contract = { abi: erc20Abi, address: tokenAddress } as const;
+  const [name, symbol, decimals] = await multicall(wagmiConfig, {
+    chainId: chainId as SupportedChainId,
+    contracts: [
+      { ...contract, functionName: "name" },
+      { ...contract, functionName: "symbol" },
+      { ...contract, functionName: "decimals" },
+    ],
+  });
+
+  if (name.status === "failure" && symbol.status === "failure" && decimals.status === "failure") {
+    return null;
+  }
+
+  return {
+    name: name.result ?? "Unknown",
+    symbol: symbol.result ?? "Unknown",
+    decimals: decimals.result, //undefined if the call failed, to facilitate checks in the UI
+  };
+};

--- a/web/src/utils/fetchTokenInfo.ts
+++ b/web/src/utils/fetchTokenInfo.ts
@@ -1,9 +1,16 @@
 import { Alchemy } from "alchemy-sdk";
 import { IToken } from "context/NewTransactionContext";
+import { fetchOnchainTokenMetadata } from "./fetchOnchainTokenMetadata";
 
-export const fetchTokenInfo = async (address: string, alchemyInstance: Alchemy) => {
+export const fetchTokenInfo = async (address: string, alchemyInstance: Alchemy, chainId: number) => {
   try {
     const metadata = await alchemyInstance.core.getTokenMetadata(address);
+
+    //Means alchemy knows nothing about the token, so we throw to try the contract directly.
+    if (!metadata.name && !metadata.symbol) {
+      throw new Error("No token metadata returned by alchemy");
+    }
+
     return {
       symbol: metadata.symbol?.toUpperCase(),
       logo: metadata.logo,
@@ -11,6 +18,16 @@ export const fetchTokenInfo = async (address: string, alchemyInstance: Alchemy) 
       decimals: metadata.decimals ?? undefined, //Set undefined if null to facilitate checks in the UI
     } as IToken;
   } catch (error) {
-    return console.error("Error fetching token info:", error);
+    const onchainMetadata = await fetchOnchainTokenMetadata(address as `0x${string}`, chainId).catch(() => null);
+
+    if (!onchainMetadata) {
+      return console.error("Error fetching token info:", error);
+    }
+
+    return {
+      symbol: onchainMetadata.symbol.toUpperCase(),
+      address,
+      decimals: onchainMetadata.decimals,
+    } as IToken;
   }
 };

--- a/web/src/utils/fetchTokenInfo.ts
+++ b/web/src/utils/fetchTokenInfo.ts
@@ -6,8 +6,8 @@ export const fetchTokenInfo = async (address: string, alchemyInstance: Alchemy, 
   try {
     const metadata = await alchemyInstance.core.getTokenMetadata(address);
 
-    //Means alchemy knows nothing about the token, so we throw to try the contract directly.
-    if (!metadata.name && !metadata.symbol) {
+    //Means alchemy metadata is missing or incomplete, so we throw to try the contract directly.
+    if (!metadata.name || !metadata.symbol) {
       throw new Error("No token metadata returned by alchemy");
     }
 
@@ -26,6 +26,7 @@ export const fetchTokenInfo = async (address: string, alchemyInstance: Alchemy, 
 
     return {
       symbol: onchainMetadata.symbol.toUpperCase(),
+      logo: "",
       address,
       decimals: onchainMetadata.decimals,
     } as IToken;

--- a/web/src/utils/initializeTokens.ts
+++ b/web/src/utils/initializeTokens.ts
@@ -12,7 +12,7 @@ export const initializeTokens = async (address: string, setTokens, setLoading, c
     const balances = await alchemyInstance.core.getTokenBalances(address);
     const tokenList = await Promise.all(
       balances.tokenBalances.map(async (token) => {
-        const tokenInfo = await fetchTokenInfo(token.contractAddress, alchemyInstance);
+        const tokenInfo = await fetchTokenInfo(token.contractAddress, alchemyInstance, chainId);
         if (tokenInfo) {
           return {
             symbol: tokenInfo.symbol,

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
       },
     },
   },
-  envPrefix: ["REACT_APP", "ALCHEMY", "INFURA", "WALLETCONNECT_PROJECT_ID"],
+  envPrefix: ["REACT_APP", "ALCHEMY_API_KEY", "INFURA_API_KEY", "WALLETCONNECT_PROJECT_ID"],
   plugins: [
     svgr({
       include: ["**/*.svg", "tsx:**/*.svg"],

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
       },
     },
   },
-  envPrefix: ["REACT_APP", "ALCHEMY", "WALLETCONNECT_PROJECT_ID"],
+  envPrefix: ["REACT_APP", "ALCHEMY", "INFURA", "WALLETCONNECT_PROJECT_ID"],
   plugins: [
     svgr({
       include: ["**/*.svg", "tsx:**/*.svg"],


### PR DESCRIPTION
Resolves #179.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for `INFURA_API_KEY`, enhances token metadata fetching, and improves error handling. It also updates the configuration for using Infura as a fallback for RPC calls.

### Detailed summary
- Added optional `INFURA_API_KEY` to `ImportMetaEnv`.
- Updated `vite.config.js` to include `INFURA_API_KEY` in `envPrefix`.
- Modified `fetchTokenInfo` and `fetchOnchainTokenMetadata` to accept `chainId`.
- Improved error handling in `useTokenMetadata` to fetch on-chain metadata if Alchemy fails.
- Introduced `infuraURL` function for Infura RPC calls.
- Updated transport configurations to include Infura as a fallback.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional fallback connectivity through Infura for Ethereum, Arbitrum, and Arbitrum Sepolia.
  * Improved token detection by retrieving metadata directly from the blockchain when primary data is unavailable.
  * Token balances now display names, symbols, and decimal precision more reliably.

* **Bug Fixes**
  * Improved handling of missing or failed token metadata requests.
  * Removed Sepolia from the supported network configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->